### PR TITLE
Add pre-commit configuration with code quality hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,62 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-ast
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-json
+      - id: check-xml
+
+  - repo: https://github.com/myint/autoflake
+    rev: v2.3.1
+    hooks:
+      - id: autoflake
+        args:
+          - --recursive
+          - --in-place
+          - --remove-all-unused-imports
+          - --remove-unused-variables
+          - --expand-star-imports
+          - --exclude
+          - __init__.py
+          - --remove-duplicate-keys
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 6.0.1
+    hooks:
+      - id: isort
+        name: isort (python)
+      - id: isort
+        name: isort (cython)
+        types: [cython]
+      - id: isort
+        name: isort (pyi)
+        types: [pyi]
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.19.1
+    hooks:
+      - id: pyupgrade
+        args: [--py3-plus]
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: debug-statements
+
+  - repo: https://github.com/AliYmn/conventional-commits-check
+    rev: v2.9.0
+    hooks:
+      - id: conventional-commits-check
+        stages: [commit-msg]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      - id: ruff
+        args: [ --fix ]
+      - id: ruff-format


### PR DESCRIPTION
## Pre-commit Configuration

This PR adds a comprehensive pre-commit configuration to our project. We've been using pre-commit hooks extensively in our professional projects and have seen significant benefits:

### Tools Included
- **Ruff**: Fast Python linter and formatter
- **isort**: Import sorting and organization
- **autoflake**: Removes unused imports and variables
- **pyupgrade**: Upgrades syntax to newer Python versions
- **conventional-commits-check**: Enforces standardized commit messages

### Usage
``` bash
pre-commit install && \
pre-commit autoupdate && \
pre-commit install --hook-type commit-msg -f
```

This configuration has proven invaluable in our other projects by maintaining high code quality standards and streamlining our development workflow.