### PR TITLE
add google mail to project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+EMAIL_HOST_USER=your_username@gmail.com
+EMAIL_HOST_PASSWORD=abcd efgh ijkl mnop
+# app passwords are 16 characters like above. but you should get it from google and put yours!

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,9 @@ db.sqlite3
 media
 
 # Virtual environment
+venv/
 .venv
+.env
 
 # Screencast
 Lithium_Demo_2025.mp4

--- a/django_project/settings.py
+++ b/django_project/settings.py
@@ -1,7 +1,10 @@
+import os
+from dotenv import load_dotenv
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(os.path.join(BASE_DIR, '.env'))
 
 
 # Quick-start development settings - unsuitable for production
@@ -165,8 +168,16 @@ CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
 CRISPY_TEMPLATE_PACK = "bootstrap5"
 
 # https://docs.djangoproject.com/en/dev/ref/settings/#email-backend
-EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = "smtp.gmail.com"
+EMAIL_PORT = 465
+EMAIL_USE_SSL = True
+EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER")
+EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD")
+# You should define EMAIL_HOST_USER and EMAIL_HOST_PASSWORD
+# in your .env file. If one of them is not found, django uses default console.EmailBackend
+if not EMAIL_HOST_USER or not EMAIL_HOST_PASSWORD:
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-from-email
 DEFAULT_FROM_EMAIL = "root@localhost"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 asgiref==3.8.1
 certifi==2022.12.7
-cffi==1.15.1
+cffi==1.17.1
 charset-normalizer==3.0.1
 crispy-bootstrap5==2024.10
 cryptography==39.0.1
@@ -16,11 +16,13 @@ packaging==23.1
 psycopg==3.2.3
 psycopg-binary==3.2.3
 pycparser==2.21
-PyJWT==2.6.0
+PyJWT==2.7.0
+python-dotenv==1.1.1
 python3-openid==3.2.0
 requests==2.28.2
 requests-oauthlib==1.3.1
 sqlparse==0.4.3
 typing_extensions==4.9.0
+tzdata==2025.2
 urllib3==1.26.14
 whitenoise==6.7.0


### PR DESCRIPTION
1- python-dotenv lib added to use .env file for username and app pasword of gmail address to send real email.
2- gitignore changed.
3- .env.example file added to show how to add .env files.
4- requirements.txt updated.
It is tested and works perfectly.